### PR TITLE
Update stock-not-in-stock.js to include 'rupture de stock'

### DIFF
--- a/changedetectionio/res/stock-not-in-stock.js
+++ b/changedetectionio/res/stock-not-in-stock.js
@@ -17,6 +17,7 @@ function isItemInStock() {
     'currently unavailable',
     'dostępne wkrótce',
     'en rupture de stock',
+    'rupture de stock',
     'ist derzeit nicht auf lager',
     'item is no longer available',
     'message if back in stock',


### PR DESCRIPTION
I tested this on my machine and it not correctly says not in stock for this url: https://store.nvidia.com/fr-fr/geforce/store/gpu/?page=1&limit=8&locale=fr-fr&category=GPU&gpu=RTX%204090&manufacturer=NVIDIA&manufacturer_filter=NVIDIA